### PR TITLE
Fix source flip without content

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -9,7 +9,10 @@
   import ThemeSelector from '$lib/components/ThemeSelector.svelte'
   import FlipButton from '$lib/components/FlipButton.svelte'
 
-  export let lang: string, toggleFlip: () => void, showsCode: boolean
+  export let lang: string
+  export let toggleFlip: () => void
+  export let showsCode: boolean
+  export let hasCode: boolean
 
   let showsNavigation: boolean
   // let height: number
@@ -33,7 +36,9 @@
         {$LL.contact()}
       </Anchor>
       <div class="row">
-        <FlipButton {toggleFlip} flipped={showsCode} />
+        {#if hasCode}
+          <FlipButton {toggleFlip} flipped={showsCode} />
+        {/if}
         <ThemeSelector />
       </div>
     </nav>

--- a/src/routes/[lang]/+layout.svelte
+++ b/src/routes/[lang]/+layout.svelte
@@ -10,6 +10,8 @@
   const { lang } = $page.params
 
   let showsCode = false
+  $: hasCode = Boolean($page.data.code)
+  $: if (!hasCode) showsCode = false
   let h = 0
   // const aspectRatio = 296.6 / 1197.07 // logo svg viewbox
   let mounted = false
@@ -34,7 +36,7 @@
 
 <!-- TODO could we avoid init-theme with #if process browser here-->
 {#if browser}
-  <Header {lang} {showsCode} {toggleFlip} />
+  <Header {lang} {showsCode} {toggleFlip} {hasCode} />
 {/if}
 
 <main style="height: {h}px; ">
@@ -45,7 +47,7 @@
           <slot />
         </div>
       </div>
-    {:else}
+    {:else if hasCode}
       <div class="side back" transition:turn={{ delay: 0, duration: 500 }}>
         <div class="content" bind:clientHeight={h}>
           <code>{$page.data.code}</code>

--- a/tests/e2e/source-flip.spec.ts
+++ b/tests/e2e/source-flip.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const sourceFlip = (page: Page) =>
+  page.getByRole('switch', { name: 'Show code' })
+
+test('only exposes the source-code flip when source is available', async ({
+  page,
+}) => {
+  await page.goto('/en/contact/christian')
+  await expect(sourceFlip(page)).toHaveCount(0)
+
+  await page.goto('/en')
+  if ((await sourceFlip(page).count()) === 0) {
+    await page.getByRole('button', { name: 'Menu' }).click()
+  }
+  await expect(sourceFlip(page)).toBeVisible()
+
+  await sourceFlip(page).click()
+  await expect(sourceFlip(page)).toHaveAttribute('aria-checked', 'true')
+  await expect(page.locator('main code')).not.toBeEmpty()
+
+  await sourceFlip(page).click()
+  await expect(sourceFlip(page)).not.toHaveAttribute('aria-checked', 'true')
+  await expect(page.locator('main code')).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary

- hide the source-code flip when the active route has no source payload
- reset/guard flipped state so navigation cannot reveal an empty back face
- add focused Playwright coverage for the wallet and source-enabled routes
- replace the obsolete Sapper Cypress scaffold with the minimal Playwright setup

Closes #103

## Verification

- `npm run test:e2e -- tests/source-flip.spec.ts` — passed (1 Chromium test)
- `npm run test:e2e` — passed (1 Chromium test)
- `npm run check` — passed (0 errors, 0 warnings)
- `PUBLIC_EMAIL=test@example.com PUBLIC_PHONENO=+4500000000 npm run build` — passed
- focused `npm run check:lint -- ...` — passed for all changed TypeScript/Svelte files
- focused `npm run check:prettier -- ...` — passed for all changed formatted files
- `git diff --check` — passed

## Existing baseline

The repository-wide `npm run lint` still reports Prettier differences in 22 unchanged legacy files on `master`. This PR does not reformat those unrelated files.
