### PR TITLE
Resolve immutable Cloudflare preview deployments

### DIFF
--- a/scripts/resolve-cloudflare-preview.mjs
+++ b/scripts/resolve-cloudflare-preview.mjs
@@ -1,0 +1,271 @@
+import { appendFile } from 'node:fs/promises'
+import { pathToFileURL } from 'node:url'
+
+const API_ORIGIN = 'https://api.cloudflare.com'
+const POLL_INTERVAL_MS = 15_000
+const MAX_WAIT_MS = 15 * 60_000
+const NON_TERMINAL_STATUSES = new Set(['idle', 'active'])
+const IMMUTABLE_PREVIEW_HOST = /^[0-9a-f]{8}\.el-danes\.pages\.dev$/
+const FULL_SHA = /^[0-9a-f]{40}$/i
+
+function requiredEnvironmentValue(env, name) {
+  const value = env[name]
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${name} is required`)
+  }
+  return value
+}
+
+function malformedApiResponse(detail) {
+  return new Error(`Malformed Cloudflare API response: ${detail}`)
+}
+
+function validatePage(body, expectedPage) {
+  if (body === null || typeof body !== 'object' || body.success !== true) {
+    throw malformedApiResponse('request was not successful')
+  }
+  if (!Array.isArray(body.result)) {
+    throw malformedApiResponse('result must be an array')
+  }
+
+  const page = body.result_info?.page
+  const totalPages = body.result_info?.total_pages
+  if (
+    !Number.isInteger(page) ||
+    page !== expectedPage ||
+    !Number.isInteger(totalPages) ||
+    totalPages < 1 ||
+    totalPages < page
+  ) {
+    throw malformedApiResponse('invalid pagination metadata')
+  }
+
+  return { deployments: body.result, totalPages }
+}
+
+function validateDeployment(value) {
+  if (value === null || typeof value !== 'object') {
+    throw malformedApiResponse('malformed deployment')
+  }
+
+  const commitHash = value.deployment_trigger?.metadata?.commit_hash
+  const status = value.latest_stage?.status
+  const { created_on: createdOn, url } = value
+  if (
+    typeof commitHash !== 'string' ||
+    typeof status !== 'string' ||
+    typeof createdOn !== 'string' ||
+    Number.isNaN(Date.parse(createdOn)) ||
+    typeof url !== 'string'
+  ) {
+    throw malformedApiResponse('malformed deployment')
+  }
+
+  return { commitHash, status, createdOn, url }
+}
+
+export function validateImmutablePreviewUrl(value) {
+  let parsed
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new Error('Expected an immutable Cloudflare preview URL')
+  }
+
+  if (
+    parsed.protocol !== 'https:' ||
+    parsed.username !== '' ||
+    parsed.password !== '' ||
+    parsed.port !== '' ||
+    !IMMUTABLE_PREVIEW_HOST.test(parsed.hostname) ||
+    parsed.pathname !== '/' ||
+    parsed.search !== '' ||
+    parsed.hash !== ''
+  ) {
+    throw new Error('Expected an immutable Cloudflare preview URL')
+  }
+
+  return parsed.origin
+}
+
+export async function fetchPreviewDeployments({
+  accountId,
+  project,
+  token,
+  fetchImpl = globalThis.fetch,
+  signal,
+}) {
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('A fetch implementation is required')
+  }
+
+  const deployments = []
+  let page = 1
+  let totalPages = 1
+
+  do {
+    const url = new URL(
+      `/client/v4/accounts/${encodeURIComponent(accountId)}/pages/projects/${encodeURIComponent(project)}/deployments`,
+      API_ORIGIN
+    )
+    url.searchParams.set('env', 'preview')
+    url.searchParams.set('page', String(page))
+
+    let apiResponse
+    try {
+      apiResponse = await fetchImpl(url, {
+        signal,
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      })
+    } catch {
+      throw new Error('Cloudflare API request failed')
+    }
+
+    if (
+      apiResponse === null ||
+      typeof apiResponse !== 'object' ||
+      apiResponse.ok !== true
+    ) {
+      const status = Number.isInteger(apiResponse?.status)
+        ? ` (${apiResponse.status})`
+        : ''
+      throw new Error(`Cloudflare API request failed${status}`)
+    }
+
+    let body
+    try {
+      body = await apiResponse.json()
+    } catch {
+      throw malformedApiResponse('response was not valid JSON')
+    }
+
+    const { deployments: pageDeployments, totalPages: validatedTotalPages } =
+      validatePage(body, page)
+    deployments.push(...pageDeployments)
+    totalPages = validatedTotalPages
+    page += 1
+  } while (page <= totalPages)
+
+  return deployments
+}
+
+export async function resolveCloudflarePreview({
+  accountId,
+  project,
+  token,
+  headSha,
+  fetchImpl = globalThis.fetch,
+  sleep = (milliseconds) =>
+    new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  now = Date.now,
+  pollIntervalMs = POLL_INTERVAL_MS,
+  maxWaitMs = MAX_WAIT_MS,
+}) {
+  if (!FULL_SHA.test(headSha)) {
+    throw new Error('PR_HEAD_SHA must be a full 40-character commit SHA')
+  }
+  if (!Number.isFinite(pollIntervalMs) || pollIntervalMs <= 0) {
+    throw new Error('Poll interval must be positive')
+  }
+  if (
+    !Number.isInteger(maxWaitMs) ||
+    maxWaitMs < 1 ||
+    maxWaitMs > 2 ** 32 - 1
+  ) {
+    throw new Error('Maximum wait must be a positive 32-bit integer')
+  }
+
+  const startedAt = now()
+  const timeoutSignal = AbortSignal.timeout(maxWaitMs)
+
+  for (;;) {
+    let rawDeployments
+    try {
+      rawDeployments = await fetchPreviewDeployments({
+        accountId,
+        project,
+        token,
+        fetchImpl,
+        signal: timeoutSignal,
+      })
+    } catch (error) {
+      if (timeoutSignal.aborted) {
+        throw new Error(
+          `Cloudflare preview resolution timed out after ${maxWaitMs / 1_000} seconds`
+        )
+      }
+      throw error
+    }
+
+    const elapsed = now() - startedAt
+    if (elapsed >= maxWaitMs) {
+      throw new Error(
+        `Cloudflare preview resolution timed out after ${maxWaitMs / 1_000} seconds`
+      )
+    }
+
+    const matching = rawDeployments
+      .map(validateDeployment)
+      .filter((candidate) => candidate.commitHash === headSha)
+      .sort(
+        (left, right) =>
+          Date.parse(right.createdOn) - Date.parse(left.createdOn)
+      )
+    const [newest] = matching
+
+    if (newest?.status === 'success') {
+      return validateImmutablePreviewUrl(newest.url)
+    }
+    if (newest && !NON_TERMINAL_STATUSES.has(newest.status)) {
+      throw new Error(
+        `Newest matching Cloudflare deployment reached terminal status: ${newest.status}`
+      )
+    }
+
+    await sleep(Math.min(pollIntervalMs, maxWaitMs - elapsed))
+  }
+}
+
+export async function runFromEnvironment({
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  sleep,
+  now,
+  appendFileImpl = appendFile,
+} = {}) {
+  const accountId = requiredEnvironmentValue(env, 'CLOUDFLARE_ACCOUNT_ID')
+  const project = requiredEnvironmentValue(env, 'CLOUDFLARE_PAGES_PROJECT')
+  const token = requiredEnvironmentValue(env, 'CLOUDFLARE_PAGES_READ_TOKEN')
+  const headSha = requiredEnvironmentValue(env, 'PR_HEAD_SHA')
+  const outputPath = requiredEnvironmentValue(env, 'GITHUB_OUTPUT')
+
+  const url = await resolveCloudflarePreview({
+    accountId,
+    project,
+    token,
+    headSha,
+    fetchImpl,
+    ...(sleep === undefined ? {} : { sleep }),
+    ...(now === undefined ? {} : { now }),
+  })
+  await appendFileImpl(outputPath, `preview_url=${url}\n`, { encoding: 'utf8' })
+  return url
+}
+
+const isDirectExecution =
+  typeof process.argv[1] === 'string' &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+
+if (isDirectExecution) {
+  runFromEnvironment().catch((error) => {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Cloudflare preview resolution failed'
+    process.stderr.write(`${message}\n`)
+    process.exitCode = 1
+  })
+}

--- a/tests/ci/resolve-cloudflare-preview.test.mjs
+++ b/tests/ci/resolve-cloudflare-preview.test.mjs
@@ -1,3 +1,412 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import test from 'node:test'
 
-test.todo('Cloudflare preview resolver tests are implemented by issue #110')
+import {
+  fetchPreviewDeployments,
+  resolveCloudflarePreview,
+  runFromEnvironment,
+  validateImmutablePreviewUrl,
+} from '../../scripts/resolve-cloudflare-preview.mjs'
+
+const HEAD_SHA = '0123456789abcdef0123456789abcdef01234567'
+const OTHER_SHA = 'abcdef0123456789abcdef0123456789abcdef01'
+
+function deployment({
+  sha = HEAD_SHA,
+  createdOn = '2026-07-29T08:00:00.000Z',
+  status = 'success',
+  url = 'https://deadbeef.el-danes.pages.dev',
+} = {}) {
+  return {
+    created_on: createdOn,
+    deployment_trigger: { metadata: { commit_hash: sha } },
+    latest_stage: { status },
+    url,
+  }
+}
+
+function response(
+  result,
+  { page = 1, totalPages = 1, ok = true, success = true } = {}
+) {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json() {
+      return Promise.resolve({
+        success,
+        result,
+        result_info: { page, total_pages: totalPages },
+      })
+    },
+  }
+}
+
+function pagedFetch(pages, calls = []) {
+  return (url, options) => {
+    const parsed = new URL(url)
+    const page = Number(parsed.searchParams.get('page') ?? '1')
+    calls.push({ parsed, options })
+    return response(pages[page - 1] ?? [], { page, totalPages: pages.length })
+  }
+}
+
+function roundsFetch(rounds) {
+  let round = 0
+  return () => {
+    const result = rounds[Math.min(round, rounds.length - 1)]
+    round += 1
+    return response(result)
+  }
+}
+
+test('accepts only a hexadecimal immutable deployment root URL', () => {
+  assert.equal(
+    validateImmutablePreviewUrl('https://0123abcd.el-danes.pages.dev'),
+    'https://0123abcd.el-danes.pages.dev'
+  )
+})
+
+test('rejects aliases, production, credentials, paths, queries, fragments, HTTP, and arbitrary origins', () => {
+  const rejected = [
+    'https://feature.el-danes.pages.dev',
+    'https://abc.el-danes.pages.dev',
+    'https://0123abcdef.el-danes.pages.dev',
+    'https://deadbeef.feature.el-danes.pages.dev',
+    'https://el-danes.pages.dev',
+    'https://user:pass@deadbeef.el-danes.pages.dev',
+    'https://deadbeef.el-danes.pages.dev/path',
+    'https://deadbeef.el-danes.pages.dev?query=yes',
+    'https://deadbeef.el-danes.pages.dev#fragment',
+    'http://deadbeef.el-danes.pages.dev',
+    'https://deadbeef.example.com',
+    'not a URL',
+  ]
+
+  for (const url of rejected) {
+    assert.throws(
+      () => validateImmutablePreviewUrl(url),
+      /immutable Cloudflare preview URL/
+    )
+  }
+})
+
+test('follows Cloudflare pagination without exposing the token in the URL', async () => {
+  const calls = []
+  const deployments = await fetchPreviewDeployments({
+    accountId: 'account/id',
+    project: 'el danes',
+    token: 'top-secret-token',
+    fetchImpl: pagedFetch(
+      [[deployment({ sha: OTHER_SHA })], [deployment()]],
+      calls
+    ),
+  })
+
+  assert.equal(deployments.length, 2)
+  assert.deepEqual(
+    calls.map(({ parsed }) => parsed.searchParams.get('page')),
+    ['1', '2']
+  )
+  for (const { parsed, options } of calls) {
+    assert.equal(parsed.searchParams.get('env'), 'preview')
+    assert.equal(
+      parsed.pathname,
+      '/client/v4/accounts/account%2Fid/pages/projects/el%20danes/deployments'
+    )
+    assert.equal(options.headers.Authorization, 'Bearer top-secret-token')
+    assert.equal(parsed.href.includes('top-secret-token'), false)
+  }
+})
+
+test('requires an exact full commit SHA match instead of accepting a prefix', async () => {
+  const resolved = await resolveCloudflarePreview({
+    accountId: 'account',
+    project: 'el-danes',
+    token: 'token',
+    headSha: HEAD_SHA,
+    fetchImpl: pagedFetch([
+      [
+        deployment({
+          sha: HEAD_SHA.slice(0, 12),
+          url: 'https://aaaaaaaa.el-danes.pages.dev',
+        }),
+        deployment({
+          sha: HEAD_SHA,
+          url: 'https://bbbbbbbb.el-danes.pages.dev',
+        }),
+      ],
+    ]),
+  })
+
+  assert.equal(resolved, 'https://bbbbbbbb.el-danes.pages.dev')
+})
+
+test('selects the newest same-SHA redeployment by created_on', async () => {
+  const resolved = await resolveCloudflarePreview({
+    accountId: 'account',
+    project: 'el-danes',
+    token: 'token',
+    headSha: HEAD_SHA,
+    fetchImpl: pagedFetch([
+      [
+        deployment({
+          createdOn: '2026-07-29T08:00:00.000Z',
+          url: 'https://aaaaaaaa.el-danes.pages.dev',
+        }),
+        deployment({
+          createdOn: '2026-07-29T08:01:00.000Z',
+          url: 'https://bbbbbbbb.el-danes.pages.dev',
+        }),
+      ],
+    ]),
+  })
+
+  assert.equal(resolved, 'https://bbbbbbbb.el-danes.pages.dev')
+})
+
+test('fails when the newest same-SHA redeployment failed even if an older one succeeded', async () => {
+  await assert.rejects(
+    resolveCloudflarePreview({
+      accountId: 'account',
+      project: 'el-danes',
+      token: 'token',
+      headSha: HEAD_SHA,
+      fetchImpl: pagedFetch([
+        [
+          deployment({
+            createdOn: '2026-07-29T08:00:00.000Z',
+            status: 'success',
+          }),
+          deployment({
+            createdOn: '2026-07-29T08:01:00.000Z',
+            status: 'failure',
+          }),
+        ],
+      ]),
+    }),
+    /terminal status: failure/
+  )
+})
+
+test('polls idle and active deployments every 15 seconds until success', async () => {
+  let now = 0
+  const sleeps = []
+  const resolved = await resolveCloudflarePreview({
+    accountId: 'account',
+    project: 'el-danes',
+    token: 'token',
+    headSha: HEAD_SHA,
+    fetchImpl: roundsFetch([
+      [deployment({ status: 'idle' })],
+      [deployment({ status: 'active' })],
+      [deployment({ status: 'success' })],
+    ]),
+    now: () => now,
+    sleep: (milliseconds) => {
+      sleeps.push(milliseconds)
+      now += milliseconds
+    },
+  })
+
+  assert.equal(resolved, 'https://deadbeef.el-danes.pages.dev')
+  assert.deepEqual(sleeps, [15_000, 15_000])
+})
+
+for (const status of ['failure', 'canceled', 'cancelled', 'skipped']) {
+  test(`fails immediately for terminal status ${status}`, async () => {
+    let slept = false
+    await assert.rejects(
+      resolveCloudflarePreview({
+        accountId: 'account',
+        project: 'el-danes',
+        token: 'token',
+        headSha: HEAD_SHA,
+        fetchImpl: pagedFetch([[deployment({ status })]]),
+        sleep: () => {
+          slept = true
+        },
+      }),
+      new RegExp(`terminal status: ${status}`)
+    )
+    assert.equal(slept, false)
+  })
+}
+
+test('times out when no matching deployment appears', async () => {
+  let now = 0
+  let requests = 0
+  await assert.rejects(
+    resolveCloudflarePreview({
+      accountId: 'account',
+      project: 'el-danes',
+      token: 'token',
+      headSha: HEAD_SHA,
+      fetchImpl: () => {
+        requests += 1
+        return response([])
+      },
+      now: () => now,
+      sleep: (milliseconds) => {
+        now += milliseconds
+      },
+      maxWaitMs: 30_000,
+    }),
+    /timed out after 30 seconds/
+  )
+  assert.equal(requests, 3)
+})
+
+test('uses a 15-minute default hard timeout', async () => {
+  const times = [0, 15 * 60_000]
+  await assert.rejects(
+    resolveCloudflarePreview({
+      accountId: 'account',
+      project: 'el-danes',
+      token: 'token',
+      headSha: HEAD_SHA,
+      fetchImpl: () => response([]),
+      now: () => times.shift(),
+    }),
+    /timed out after 900 seconds/
+  )
+})
+
+test('does not accept a successful response that arrives after the deadline', async () => {
+  const times = [0, 15 * 60_000 + 1]
+  await assert.rejects(
+    resolveCloudflarePreview({
+      accountId: 'account',
+      project: 'el-danes',
+      token: 'token',
+      headSha: HEAD_SHA,
+      fetchImpl: () => response([deployment()]),
+      now: () => times.shift(),
+    }),
+    /timed out after 900 seconds/
+  )
+})
+
+test('rejects malformed API responses', async () => {
+  const malformedResponses = [
+    { ok: false, status: 503, json: () => Promise.resolve({}) },
+    {
+      ok: true,
+      status: 200,
+      json: () => Promise.reject(new Error('bad json')),
+    },
+    {
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          success: false,
+          result: [],
+          result_info: { page: 1, total_pages: 1 },
+        }),
+    },
+    {
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          success: true,
+          result: {},
+          result_info: { page: 1, total_pages: 1 },
+        }),
+    },
+    {
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          success: true,
+          result: [],
+          result_info: { page: 1 },
+        }),
+    },
+  ]
+
+  for (const malformed of malformedResponses) {
+    await assert.rejects(
+      fetchPreviewDeployments({
+        accountId: 'account',
+        project: 'el-danes',
+        token: 'token',
+        fetchImpl: () => malformed,
+      }),
+      /Cloudflare API/
+    )
+  }
+})
+
+test('rejects malformed matching deployment records', async () => {
+  const malformed = deployment()
+  delete malformed.latest_stage
+
+  await assert.rejects(
+    resolveCloudflarePreview({
+      accountId: 'account',
+      project: 'el-danes',
+      token: 'token',
+      headSha: HEAD_SHA,
+      fetchImpl: pagedFetch([[malformed]]),
+    }),
+    /malformed deployment/
+  )
+})
+
+test('reads canonical environment variables and writes only the validated URL output', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'el-danes-resolver-'))
+  const outputPath = join(directory, 'github-output')
+  try {
+    const resolved = await runFromEnvironment({
+      env: {
+        CLOUDFLARE_ACCOUNT_ID: 'account',
+        CLOUDFLARE_PAGES_PROJECT: 'el-danes',
+        CLOUDFLARE_PAGES_READ_TOKEN: 'top-secret-token',
+        PR_HEAD_SHA: HEAD_SHA,
+        GITHUB_OUTPUT: outputPath,
+      },
+      fetchImpl: pagedFetch([[deployment()]]),
+    })
+
+    assert.equal(resolved, 'https://deadbeef.el-danes.pages.dev')
+    assert.equal(
+      await readFile(outputPath, 'utf8'),
+      'preview_url=https://deadbeef.el-danes.pages.dev\n'
+    )
+    assert.equal(
+      (await readFile(outputPath, 'utf8')).includes('top-secret-token'),
+      false
+    )
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('rejects missing environment values and non-full head SHAs', async () => {
+  const base = {
+    CLOUDFLARE_ACCOUNT_ID: 'account',
+    CLOUDFLARE_PAGES_PROJECT: 'el-danes',
+    CLOUDFLARE_PAGES_READ_TOKEN: 'token',
+    PR_HEAD_SHA: HEAD_SHA,
+    GITHUB_OUTPUT: '/tmp/output',
+  }
+
+  for (const name of Object.keys(base)) {
+    await assert.rejects(
+      runFromEnvironment({ env: { ...base, [name]: '' } }),
+      new RegExp(name)
+    )
+  }
+  await assert.rejects(
+    runFromEnvironment({
+      env: { ...base, PR_HEAD_SHA: HEAD_SHA.slice(0, 12) },
+    }),
+    /PR_HEAD_SHA must be a full 40-character commit SHA/
+  )
+})


### PR DESCRIPTION
## Summary
- add the repository-owned Node 22 Cloudflare Pages preview resolver
- paginate and poll for the newest full-SHA deployment, failing closed on terminal or timeout states
- validate only immutable eight-character hexadecimal `el-danes.pages.dev` roots and emit the public URL through `GITHUB_OUTPUT`
- add Node built-in coverage for pagination, matching, redeployments, polling, failures, timeout, malformed responses, URL validation, and output handling

## Verification
- `npm ci`
- `npm run test:preview-resolver` (18 tests passed)
- `PUBLIC_EMAIL=e2e@example.invalid PUBLIC_PHONENO=+120****0123 npm run check`
- targeted Prettier and ESLint checks for all changed files
- `PUBLIC_EMAIL=e2e@example.invalid PUBLIC_PHONENO=+120****0123 npm run build`
- `git diff --check`

Repository-wide `npm run lint` remains red on 25 pre-existing legacy files outside this PR; all changed files pass Prettier and ESLint.

Closes #110