### PR TITLE
Render a meaningful 404 error state

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  let title: string
+  import { page } from '$app/stores'
 </script>
 
-<h1>{title}</h1>
+<h1>{$page.status}: {$page.error?.message ?? 'Page not found'}</h1>

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,4 +1,3 @@
-import { browser } from '$app/environment'
 import { redirect, error } from '@sveltejs/kit'
 import { baseLocale, locales } from '$i18n/i18n-util'
 import { loadLocaleAsync } from '$i18n/i18n-util.async'
@@ -10,15 +9,18 @@ export const prerender = true
 
 export const load: LayoutLoad = async ({ params, url }) => {
   const { pathname } = url
-  const { lang } = <{ lang: Locales }>params
+  const lang = params.lang as Locales | undefined
 
   // DEV only - cloudflare redirects 🔥
   if (pathname === '/') {
-    redirect(302, `/${baseLocale}`);
+    redirect(302, `/${baseLocale}`)
   }
+  // Unmatched routes have no language parameter; preserve their original 404.
+  if (lang === undefined) return
+
   // Unsupported language redirect to 404
   if (!locales.includes(lang)) {
-    error(404, `${lang} language is not supported.`);
+    error(404, `${lang} language is not supported.`)
   }
 
   await loadLocaleAsync(lang)

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -24,7 +24,7 @@ const config = {
     adapter: adapter({
       pages: 'build',
       assets: 'build',
-      fallback: undefined,
+      fallback: '404.html',
       precompress: false,
       strict: true,
     }),

--- a/tests/e2e/error.spec.ts
+++ b/tests/e2e/error.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test'
+
+const errorRoutes = [
+  { path: '/fr', expectedHeading: /not supported/i },
+  { path: '/en/unknown-route', expectedHeading: /not found/i },
+] as const
+
+for (const { path, expectedHeading } of errorRoutes) {
+  test(`${path} returns a meaningful not-found page`, async ({ page }) => {
+    const response = await page.goto(path)
+
+    expect(response?.status()).toBe(404)
+    await expect(page.getByRole('heading', { level: 1 })).toContainText(
+      expectedHeading
+    )
+  })
+}


### PR DESCRIPTION
## Summary
- render the SvelteKit status and error message in the shared error heading
- preserve the original not-found error for unmatched nested routes
- generate a top-level `404.html` fallback so Cloudflare Pages returns a real 404 instead of the homepage
- cover unsupported locales and unknown routes with Playwright

## Verification
- `npm run verify`
- `PUBLIC_EMAIL=e2e@example.invalid PUBLIC_PHONENO=+120****0123 npm run build`
- focused Prettier and ESLint checks for changed files
- `git diff --check`

Closes #102