### PR TITLE
Expose mobile navigation expanded state accessibly

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -11,7 +11,7 @@
 
   export let lang: string, toggleFlip: () => void, showsCode: boolean
 
-  let showsNavigation: boolean
+  let showsNavigation = false
   // let height: number
 
   onMount(() => {
@@ -27,7 +27,11 @@
 
 <header>
   {#if showsNavigation}
-    <nav class="row {$theme && 'visible'}" transition:slide>
+    <nav
+      id="primary-navigation"
+      class="row {$theme && 'visible'}"
+      transition:slide
+    >
       <LanguageSelector {lang} />
       <Anchor id="contact-link" href="/contact">
         {$LL.contact()}
@@ -40,7 +44,13 @@
   {/if}
   <Logo {lang} turn={showsCode}>
     <div class="handheld-row">
-      <button on:click={toggleShowsNavigation} type="button">
+      <button
+        id="mobile-navigation-toggle"
+        type="button"
+        aria-controls="primary-navigation"
+        aria-expanded={showsNavigation}
+        on:click={toggleShowsNavigation}
+      >
         {showsNavigation ? $LL.back() : $LL.menu()}
       </button>
     </div>

--- a/tests/e2e/mobile-navigation.spec.ts
+++ b/tests/e2e/mobile-navigation.spec.ts
@@ -1,0 +1,72 @@
+import AxeBuilder from '@axe-core/playwright'
+
+import { expect, test, type Page } from './fixtures/health'
+import { routes } from './routes'
+
+const spanishHome = routes.find((route) => route.path === '/es')
+if (!spanishHome)
+  throw new Error('Spanish home route is missing from the manifest')
+
+async function seriousOrCriticalToggleViolations(page: Page) {
+  const axeResults = await new AxeBuilder({ page })
+    .include('#mobile-navigation-toggle')
+    .analyze()
+  return axeResults.violations.filter((violation) =>
+    ['serious', 'critical'].includes(violation.impact ?? '')
+  )
+}
+
+test.describe('mobile navigation', () => {
+  test.skip(
+    ({ isMobile }) => !isMobile,
+    'Mobile navigation is viewport-specific'
+  )
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(spanishHome.path)
+  })
+
+  test('exposes state and supports pointer and keyboard activation', async ({
+    page,
+  }) => {
+    const toggle = page.locator('#mobile-navigation-toggle')
+
+    await expect(toggle).toHaveAccessibleName('menu')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(
+      await seriousOrCriticalToggleViolations(page),
+      'serious or critical collapsed toggle violations'
+    ).toEqual([])
+
+    await toggle.click()
+    await expect(toggle).toHaveAccessibleName('back')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.getByRole('navigation')).toBeVisible()
+
+    expect(
+      await seriousOrCriticalToggleViolations(page),
+      'serious or critical expanded toggle violations'
+    ).toEqual([])
+
+    await page.getByRole('button', { name: 'back' }).click()
+    await expect(toggle).toHaveAccessibleName('menu')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    await toggle.focus()
+    await page.keyboard.press('Enter')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+
+    await page.keyboard.press('Space')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  test('navigates through a localized menu link', async ({ page }) => {
+    const toggle = page.getByRole('button', { name: 'menu' })
+
+    await toggle.click()
+    await page.getByRole('link', { name: 'Contacto' }).click()
+
+    await expect(page).toHaveURL(/\/es\/contact\/?$/)
+    await expect(page.locator('html')).toHaveAttribute('lang', 'es')
+  })
+})


### PR DESCRIPTION
## Summary
- initialize mobile navigation as collapsed and expose its state with `aria-expanded`
- associate the toggle with the primary navigation through `aria-controls`
- add mobile Playwright regression coverage for accessible naming/state, pointer and keyboard activation, localized navigation, and collapsed/expanded axe checks

## Verification
- `npm run test:e2e:project -- tests/e2e/mobile-navigation.spec.ts --project=mobile-chromium` (2 passed)
- `npm run verify` (Svelte check clean, E2E format/lint clean, preview resolver 18 passed, Playwright 4 passed / 2 desktop-only skips)
- `PUBLIC_EMAIL=e2e@example.invalid PUBLIC_PHONENO=+120****0123 npm run build`
- targeted Prettier checks for both changed files and ESLint for the E2E spec
- `git diff --check`
- static added-line security scan

Repository-wide `npm run lint` remains red on 22 pre-existing Prettier files outside this change; both changed files pass Prettier.

Closes #105
