### PR TITLE
Preserve subpages when switching locale

### DIFF
--- a/src/lib/components/LanguageSelector.svelte
+++ b/src/lib/components/LanguageSelector.svelte
@@ -1,6 +1,11 @@
 <script>
+  import { page } from '$app/stores'
   import Anchor from '$lib/components/Anchor.svelte'
   export let lang
+
+  $: currentRoute = `${$page.url.pathname.replace(/^\/[^/]+/, '')}${
+    $page.url.search
+  }${$page.url.hash}`
 </script>
 
 <ul>
@@ -9,7 +14,7 @@
     <Anchor
       aria-current={lang === 'en' ? 'language' : undefined}
       class="language-switch"
-      href="/en"
+      href={`/en${currentRoute}`}
       target="_self"
     >
       EN
@@ -19,7 +24,7 @@
     <Anchor
       aria-current={lang === 'es' ? 'language' : undefined}
       class="language-switch"
-      href="/es"
+      href={`/es${currentRoute}`}
       target="_self"
     >
       SP
@@ -29,7 +34,7 @@
     <Anchor
       aria-current={lang === 'da' ? 'language' : undefined}
       class="language-switch"
-      href="/da"
+      href={`/da${currentRoute}`}
       target="_self"
     >
       DA

--- a/tests/e2e/locale-switching.spec.ts
+++ b/tests/e2e/locale-switching.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from './fixtures/health'
+
+const localeChoices = [
+  { locale: 'da', label: 'DA', landmark: 'Holder godt selskab.' },
+  { locale: 'es', label: 'SP', landmark: 'En buena compañia.' },
+  { locale: 'en', label: 'EN', landmark: 'Keeping good company.' },
+] as const
+
+test('preserves the current subpage when switching between locales', async ({
+  page,
+}) => {
+  await page.goto('/en/cases')
+
+  for (const choice of localeChoices) {
+    const languageLink = page.getByRole('link', {
+      name: choice.label,
+      exact: true,
+    })
+    if (!(await languageLink.isVisible())) {
+      await page.getByRole('button', { name: 'menu' }).click()
+    }
+
+    await languageLink.click()
+
+    await expect(page).toHaveURL(`/${choice.locale}/cases`)
+    await expect(page.locator('html')).toHaveAttribute('lang', choice.locale)
+    await expect(page.locator('footer .title')).toHaveText(choice.landmark)
+    if (!(await page.locator('a.language-switch').first().isVisible())) {
+      await page.getByRole('button', { name: 'menu' }).click()
+    }
+    await expect(
+      page.locator('a.language-switch[aria-current="language"]')
+    ).toHaveText(choice.label)
+  }
+})


### PR DESCRIPTION
## Summary
- preserve the current route, query, and fragment in locale-selector links
- keep the selected locale reflected in the URL and active-language state
- add desktop and mobile Playwright coverage across English, Danish, and Spanish from `/cases`

## Verification
- `npm run verify`
- `PUBLIC_EMAIL=e2e@example.invalid PUBLIC_PHONENO=+120****0123 npm run build`
- focused desktop/mobile locale-switching Playwright spec
- `npm run check`
- `npm run check:e2e`
- `npm run lint` (pre-existing Prettier failures in 22 untouched files)
- `git diff --check`

Closes #101