### PR TITLE
Give Christian wallet pages localized document titles

### DIFF
--- a/src/i18n/da/index.ts
+++ b/src/i18n/da/index.ts
@@ -3,6 +3,7 @@ import type { BaseTranslation } from '../i18n-types'
 const da: BaseTranslation = {
   cases: 'Cases',
   contact: 'Kontakt',
+  walletTitle: 'Christians kontaktkort',
   letsTalk: 'Lad os tage en snak??',
   goodCompany: 'Holder godt selskab.',
   view: 'se!',

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -3,6 +3,7 @@ import type { BaseTranslation } from '../i18n-types'
 const en: BaseTranslation = {
   cases: 'Cases',
   contact: 'Contact',
+  walletTitle: "Christian's contact card",
   letsTalk: "Let's talk??",
   goodCompany: 'Keeping good company.',
   view: 'view!',

--- a/src/i18n/es/index.ts
+++ b/src/i18n/es/index.ts
@@ -3,6 +3,7 @@ import type { BaseTranslation } from '../i18n-types'
 const es: BaseTranslation = {
   cases: 'Cases',
   contact: 'Contacto',
+  walletTitle: 'Tarjeta de contacto de Christian',
   letsTalk: 'Hablamos??',
   goodCompany: 'En buena compañia.',
   view: 'ver!',

--- a/src/i18n/i18n-types.ts
+++ b/src/i18n/i18n-types.ts
@@ -24,6 +24,10 @@ type RootTranslation = {
 	 */
 	contact: string
 	/**
+	 * C​h​r​i​s​t​i​a​n​'​s​ ​c​o​n​t​a​c​t​ ​c​a​r​d
+	 */
+	walletTitle: string
+	/**
 	 * L​e​t​'​s​ ​t​a​l​k​?​?
 	 */
 	letsTalk: string
@@ -226,6 +230,10 @@ export type TranslationFunctions = {
 	 * Contact
 	 */
 	contact: () => LocalizedString
+	/**
+	 * Christian's contact card
+	 */
+	walletTitle: () => LocalizedString
 	/**
 	 * Let's talk??
 	 */

--- a/src/routes/[lang]/contact/christian/+page.svelte
+++ b/src/routes/[lang]/contact/christian/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { browser } from '$app/environment'
   import { page } from '$app/stores'
+  import { LL } from '$i18n/i18n-svelte'
+  import SEO from '$lib/components/SEO.svelte'
 
   const { lang } = $page.params
 
@@ -25,6 +27,8 @@
     }
   }
 </script>
+
+<SEO title={$LL.walletTitle()} />
 
 <div class="container">
   <a rel="external" href={pkpass}>

--- a/tests/e2e/accessibility-exceptions.ts
+++ b/tests/e2e/accessibility-exceptions.ts
@@ -9,22 +9,7 @@ export interface AccessibilityException {
   bugURL: `https://github.com/${string}`
 }
 
-const walletRoutes = [
-  '/en/contact/christian',
-  '/da/contact/christian',
-  '/es/contact/christian',
-] as const
-
-export const accessibilityExceptions: readonly AccessibilityException[] = [
-  {
-    rule: 'document-title',
-    routes: walletRoutes,
-    projects: ['desktop-chromium', 'firefox'],
-    maxAffectedNodes: 1,
-    rationale: 'Measured missing wallet document title; scope may only shrink.',
-    bugURL: 'https://github.com/zwergius/el-danes/issues/108',
-  },
-]
+export const accessibilityExceptions: readonly AccessibilityException[] = []
 
 export function accessibilityExceptionsFor(
   route: RouteContract['path'],

--- a/tests/e2e/wallet-title.spec.ts
+++ b/tests/e2e/wallet-title.spec.ts
@@ -1,0 +1,40 @@
+import AxeBuilder from '@axe-core/playwright'
+
+import { expect, test } from './fixtures/health'
+import { routes, type Locale, type ProjectName } from './routes'
+
+const desktopUserAgent =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/127.0.0.0 Safari/537.36'
+
+test.use({ userAgent: desktopUserAgent })
+
+const expectedTitles: Record<Locale, string> = {
+  en: "Christian's contact card - El Danés Solutions",
+  da: 'Christians kontaktkort - El Danés Solutions',
+  es: 'Tarjeta de contacto de Christian - El Danés Solutions',
+}
+
+const walletRoutes = routes.filter((route) => route.kind === 'wallet')
+
+for (const route of walletRoutes) {
+  test(`${route.locale} wallet has a localized document title`, async ({
+    page,
+    pageHealth,
+  }, testInfo) => {
+    test.skip(!route.projects.includes(testInfo.project.name as ProjectName))
+
+    const response = await page.goto(route.path)
+
+    await pageHealth.assertLoaded(response, route)
+    await expect(page).toHaveTitle(expectedTitles[route.locale])
+
+    const axeResults = await new AxeBuilder({ page })
+      .withRules(['document-title'])
+      .analyze()
+    const seriousOrCritical = axeResults.violations.filter((violation) =>
+      ['serious', 'critical'].includes(violation.impact ?? '')
+    )
+
+    expect(seriousOrCritical).toEqual([])
+  })
+}


### PR DESCRIPTION
## What changed

- added localized Christian wallet page titles in English, Danish, and Spanish
- rendered the title through the existing SEO component
- removed the temporary `document-title` accessibility exception
- added focused desktop Playwright coverage for all three wallet routes and the axe `document-title` rule

## Why

The localized Christian wallet routes rendered an empty `<title>`, causing Axe\u2019s serious `document-title` violation.

Closes #108

## Acceptance criteria checked

- [x] `/en/contact/christian`, `/da/contact/christian`, and `/es/contact/christian` have meaningful localized titles
- [x] Axe reports no serious or critical `document-title` violation
- [x] Focused desktop Playwright regression covers all three locales
- [x] Existing Apple/Google Wallet redirect logic is unchanged

## How to test

- `CI=1 npm run test:e2e:project -- tests/e2e/wallet-title.spec.ts --project=desktop-chromium` \u2014 3 passed
- `CI=1 npm run verify` \u2014 17 passed, 7 expected project skips; typecheck, E2E lint, and 18 resolver tests passed
- `git diff --check`

## Risk

Low. The runtime change is limited to document metadata and localized copy; redirect conditions and wallet links are unchanged.

## Intentionally not done

- no changes to device-specific wallet redirects
- no unrelated accessibility fixes

## Agent involvement

Implemented and verified by Hermes Agent after two delegated workers failed before execution due a provider streaming transport error.

## Follow-up issues

None.