### PR TITLE
Add navigation and user-journey E2E coverage

### DIFF
--- a/src/routes/[lang]/contact/+page.svelte
+++ b/src/routes/[lang]/contact/+page.svelte
@@ -11,11 +11,6 @@
   $: ({ phoneNo, email } = data)
 
   $pageHeader = $LL.letsTalk()
-
-  function handleEmail(e: Event) {
-    e.preventDefault()
-    window.location.href = `mailto:${email}?subject=${$LL.mailToSubject()}`
-  }
 </script>
 
 <SEO title={$LL.contact()} />
@@ -23,7 +18,10 @@
 <section>
   <ul>
     <li>
-      <Anchor onClick={handleEmail}>{email}</Anchor>
+      <Anchor
+        href={`mailto:${email}?subject=${$LL.mailToSubject()}`}
+        target="_self">{email}</Anchor
+      >
     </li>
     <li>
       <Anchor id="telephone-link" href={`tel:${phoneNo}`} target="_self">

--- a/src/routes/[lang]/contact/+page.svelte
+++ b/src/routes/[lang]/contact/+page.svelte
@@ -11,6 +11,11 @@
   $: ({ phoneNo, email } = data)
 
   $pageHeader = $LL.letsTalk()
+
+  function handleEmail(e: Event) {
+    e.preventDefault()
+    window.location.href = `mailto:${email}?subject=${$LL.mailToSubject()}`
+  }
 </script>
 
 <SEO title={$LL.contact()} />
@@ -18,10 +23,7 @@
 <section>
   <ul>
     <li>
-      <Anchor
-        href={`mailto:${email}?subject=${$LL.mailToSubject()}`}
-        target="_self">{email}</Anchor
-      >
+      <Anchor onClick={handleEmail}>{email}</Anchor>
     </li>
     <li>
       <Anchor id="telephone-link" href={`tel:${phoneNo}`} target="_self">

--- a/src/routes/[lang]/contact/christian/+page.svelte
+++ b/src/routes/[lang]/contact/christian/+page.svelte
@@ -34,7 +34,7 @@
       alt="add the card to your wallet for ios"
     />
   </a>
-  <a rel="external" target="_blank" href={passGoogle}>
+  <a rel="external noopener" target="_blank" href={passGoogle}>
     <img
       class="wallet-logo"
       src="/google-wallet-{lang}.svg"

--- a/tests/e2e/case-details.spec.ts
+++ b/tests/e2e/case-details.spec.ts
@@ -3,12 +3,12 @@ import AxeBuilder from '@axe-core/playwright'
 import { expect, test } from './fixtures/health'
 import { routes } from './routes'
 
-const casesRoute = routes.find((route) => route.path === '/en/cases')
-if (!casesRoute)
+const casesPath = routes.find((route) => route.path === '/en/cases')?.path
+if (!casesPath)
   throw new Error('English cases route is missing from the manifest')
 
 async function openCases(page: import('@playwright/test').Page) {
-  await page.goto(casesRoute.path)
+  await page.goto(casesPath)
   await page.evaluate(() => document.fonts.ready)
   const linkedCase = page
     .locator('[data-case]')
@@ -18,16 +18,35 @@ async function openCases(page: import('@playwright/test').Page) {
   return linkedCase
 }
 
-test('reveals case details with pointer and keyboard without nested controls', async ({
+test('renders deployed cases with accessible details and link contracts', async ({
   page,
-}, testInfo) => {
-  test.skip(testInfo.project.name !== 'desktop-chromium')
-
+  isMobile,
+}) => {
   const linkedCase = await openCases(page)
   const caseLink = linkedCase.getByRole('link')
   const detailsButton = linkedCase.getByRole('button')
   const details = linkedCase.locator('[data-case-details]')
   const nextCase = linkedCase.locator('xpath=following-sibling::*[1]')
+
+  const cases = page.locator('[data-case]')
+  expect(await cases.count()).toBeGreaterThan(0)
+  for (const link of await cases.getByRole('link').all()) {
+    const href = await link.getAttribute('href')
+    expect(href).toBeTruthy()
+    expect(new URL(href!).protocol).toBe('https:')
+    await expect(link).toHaveAttribute('target', '_blank')
+    await expect(link).toHaveAttribute('rel', /\bnoopener\b/)
+  }
+
+  await expect(linkedCase.locator('button a, a button')).toHaveCount(0)
+
+  if (isMobile) {
+    await expect(details).toBeHidden()
+    await detailsButton.tap()
+    await expect(detailsButton).toHaveAttribute('aria-expanded', 'true')
+    await expect(details).toBeVisible()
+    return
+  }
 
   await expect(details).toBeHidden()
   await caseLink.hover()
@@ -82,14 +101,6 @@ test('reveals case details with pointer and keyboard without nested controls', a
   await expect(detailsButton).toHaveAttribute('aria-expanded', 'true')
   await expect(details).toBeVisible()
 
-  const href = await caseLink.getAttribute('href')
-  expect(href).toBeTruthy()
-  expect(new URL(href!).protocol).toBe('https:')
-  await expect(caseLink).toHaveAttribute('target', '_blank')
-  await expect(caseLink).toHaveAttribute('rel', /\bnoopener\b/)
-
-  await expect(linkedCase.locator('button a, a button')).toHaveCount(0)
-
   const axeResults = await new AxeBuilder({ page })
     .include('[data-case]')
     .analyze()
@@ -97,17 +108,4 @@ test('reveals case details with pointer and keyboard without nested controls', a
     ['serious', 'critical'].includes(violation.impact ?? '')
   )
   expect(seriousOrCritical).toEqual([])
-})
-
-test('reveals case details by touch on mobile', async ({ page }, testInfo) => {
-  test.skip(testInfo.project.name !== 'mobile-chromium')
-
-  const linkedCase = await openCases(page)
-  const detailsButton = linkedCase.getByRole('button')
-  const details = linkedCase.locator('[data-case-details]')
-
-  await expect(details).toBeHidden()
-  await detailsButton.tap()
-  await expect(detailsButton).toHaveAttribute('aria-expanded', 'true')
-  await expect(details).toBeVisible()
 })

--- a/tests/e2e/contact-links-wallet.spec.ts
+++ b/tests/e2e/contact-links-wallet.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test, type Page, type Request } from '@playwright/test'
+
+const socialDestinations = {
+  instagram: 'https://www.instagram.com/el.danes/',
+  github: 'https://github.com/zwergius',
+  linkedin: 'https://www.linkedin.com/in/christian-zwergius',
+  behance: 'https://www.behance.net/christizwergiu',
+} as const
+
+function waitForAttempt(
+  page: Page,
+  // ESLint's base rule treats type-only parameter names as runtime variables.
+  // eslint-disable-next-line no-unused-vars
+  predicate: (request: Request) => boolean
+) {
+  return page.waitForEvent('request', { predicate })
+}
+
+test('validates contact and social destinations without visiting them', async ({
+  page,
+}) => {
+  await page.goto('/en/contact')
+
+  const phoneLink = page.locator('#telephone-link')
+  const displayedPhone = (await phoneLink.textContent())?.trim()
+  expect(displayedPhone).toBeTruthy()
+  await expect(phoneLink).toHaveAttribute('href', `tel:${displayedPhone}`)
+  await expect(phoneLink).toHaveAttribute('target', '_self')
+
+  const emailLink = page.getByRole('link', { name: /@/ })
+  const displayedEmail = (await emailLink.textContent())?.trim()
+  expect(displayedEmail).toBeTruthy()
+  const mailto = new URL((await emailLink.getAttribute('href'))!)
+  expect(mailto.protocol).toBe('mailto:')
+  expect(mailto.pathname).toBe(displayedEmail)
+  expect(mailto.searchParams.get('subject')).toBeTruthy()
+  await expect(emailLink).toHaveAttribute('target', '_self')
+
+  for (const [name, destination] of Object.entries(socialDestinations)) {
+    const link = page.getByRole('link', { name, exact: true })
+    await expect(link).toHaveAttribute('href', destination)
+    await expect(link).toHaveAttribute('target', '_blank')
+    await expect(link).toHaveAttribute('rel', /\bnoopener\b/)
+    expect(new URL(destination).protocol).toBe('https:')
+  }
+})
+
+test('validates wallet choices or captures the platform handoff', async ({
+  page,
+}, testInfo) => {
+  if (testInfo.project.name === 'mobile-chromium') {
+    await page.route('https://pay.google.com/**', (route) => route.abort())
+    const handoff = waitForAttempt(page, (request) =>
+      request.url().startsWith('https://pay.google.com/gp/v/save/')
+    )
+    await page.goto('/en/contact/christian')
+    expect(new URL((await handoff).url()).protocol).toBe('https:')
+    return
+  }
+
+  if (testInfo.project.name === 'webkit') {
+    await page.route('**/el-danes.pkpass', (route) => route.abort())
+    const handoff = waitForAttempt(page, (request) =>
+      request.url().endsWith('/el-danes.pkpass')
+    )
+    await page.goto('/en/contact/christian')
+    const pkpass = new URL((await handoff).url())
+    expect(pkpass.pathname).toBe('/el-danes.pkpass')
+    expect(pkpass.origin).toBe(new URL(page.url()).origin)
+    return
+  }
+
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      get: () => 'Mozilla/5.0 (X11; Linux x86_64)',
+    })
+  })
+  await page.goto('/en/contact/christian')
+
+  const apple = page.getByRole('link', { name: /wallet for ios/i })
+  const google = page.getByRole('link', { name: /wallet for android/i })
+  const appleURL = new URL((await apple.getAttribute('href'))!, page.url())
+  const googleURL = new URL((await google.getAttribute('href'))!)
+
+  expect(appleURL.origin).toBe(new URL(page.url()).origin)
+  expect(appleURL.pathname).toBe('/el-danes.pkpass')
+  expect(googleURL.protocol).toBe('https:')
+  expect(googleURL.hostname).toBe('pay.google.com')
+  await expect(google).toHaveAttribute('target', '_blank')
+  await expect(google).toHaveAttribute('rel', /\bnoopener\b/)
+})

--- a/tests/e2e/contact-links-wallet.spec.ts
+++ b/tests/e2e/contact-links-wallet.spec.ts
@@ -27,14 +27,18 @@ test('validates contact and social destinations without visiting them', async ({
   await expect(phoneLink).toHaveAttribute('href', `tel:${displayedPhone}`)
   await expect(phoneLink).toHaveAttribute('target', '_self')
 
-  const emailLink = page.getByRole('link', { name: /@/ })
-  const displayedEmail = (await emailLink.textContent())?.trim()
+  const emailButton = page.getByRole('button', { name: /@/ })
+  const displayedEmail = (await emailButton.textContent())?.trim()
   expect(displayedEmail).toBeTruthy()
-  const mailto = new URL((await emailLink.getAttribute('href'))!)
+  await expect(emailButton).not.toHaveAttribute('href', /./)
+  const handoff = waitForAttempt(page, (request) =>
+    request.url().startsWith('mailto:')
+  )
+  await emailButton.click()
+  const mailto = new URL((await handoff).url())
   expect(mailto.protocol).toBe('mailto:')
   expect(mailto.pathname).toBe(displayedEmail)
   expect(mailto.searchParams.get('subject')).toBeTruthy()
-  await expect(emailLink).toHaveAttribute('target', '_self')
 
   for (const [name, destination] of Object.entries(socialDestinations)) {
     const link = page.getByRole('link', { name, exact: true })

--- a/tests/e2e/contact-links-wallet.spec.ts
+++ b/tests/e2e/contact-links-wallet.spec.ts
@@ -53,7 +53,7 @@ test('validates wallet choices or captures the platform handoff', async ({
     const handoff = waitForAttempt(page, (request) =>
       request.url().startsWith('https://pay.google.com/gp/v/save/')
     )
-    await page.goto('/en/contact/christian')
+    await page.goto('/en/contact/christian', { waitUntil: 'commit' })
     expect(new URL((await handoff).url()).protocol).toBe('https:')
     return
   }
@@ -63,7 +63,7 @@ test('validates wallet choices or captures the platform handoff', async ({
     const handoff = waitForAttempt(page, (request) =>
       request.url().endsWith('/el-danes.pkpass')
     )
-    await page.goto('/en/contact/christian')
+    await page.goto('/en/contact/christian', { waitUntil: 'commit' })
     const pkpass = new URL((await handoff).url())
     expect(pkpass.pathname).toBe('/el-danes.pkpass')
     expect(pkpass.origin).toBe(new URL(page.url()).origin)

--- a/tests/e2e/locale-switching.spec.ts
+++ b/tests/e2e/locale-switching.spec.ts
@@ -1,35 +1,54 @@
-import { expect, test } from './fixtures/health'
+import { expect, test, type Page } from './fixtures/health'
 
 const localeChoices = [
-  { locale: 'da', label: 'DA', landmark: 'Holder godt selskab.' },
-  { locale: 'es', label: 'SP', landmark: 'En buena compañia.' },
-  { locale: 'en', label: 'EN', landmark: 'Keeping good company.' },
+  { locale: 'da', label: 'DA' },
+  { locale: 'es', label: 'SP' },
+  { locale: 'en', label: 'EN' },
 ] as const
+
+async function exposeLanguageNavigation(page: Page, isMobile: boolean) {
+  if (isMobile) {
+    await expect(page.locator('#mobile-navigation-toggle')).toBeVisible()
+    const menuButton = page.getByRole('button', { name: 'menu' })
+    if (await menuButton.isVisible()) await menuButton.click()
+  }
+  await expect(page.locator('a.language-switch').first()).toBeVisible()
+}
 
 test('preserves the current subpage when switching between locales', async ({
   page,
+  isMobile,
 }) => {
-  await page.goto('/en/cases')
-
-  for (const choice of localeChoices) {
-    const languageLink = page.getByRole('link', {
-      name: choice.label,
-      exact: true,
+  const subpages = ['cases', 'contact']
+  if (!isMobile) {
+    subpages.push('contact/christian')
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'userAgent', {
+        configurable: true,
+        get: () => 'Mozilla/5.0 (X11; Linux x86_64)',
+      })
     })
-    if (!(await languageLink.isVisible())) {
-      await page.getByRole('button', { name: 'menu' }).click()
-    }
+  }
 
-    await languageLink.click()
+  for (const subpage of subpages) {
+    await page.goto(`/en/${subpage}`)
 
-    await expect(page).toHaveURL(`/${choice.locale}/cases`)
-    await expect(page.locator('html')).toHaveAttribute('lang', choice.locale)
-    await expect(page.locator('footer .title')).toHaveText(choice.landmark)
-    if (!(await page.locator('a.language-switch').first().isVisible())) {
-      await page.getByRole('button', { name: 'menu' }).click()
+    for (const choice of localeChoices) {
+      await exposeLanguageNavigation(page, isMobile)
+      const languageLink = page.getByRole('link', {
+        name: choice.label,
+        exact: true,
+      })
+      await expect(languageLink).toBeVisible()
+
+      await languageLink.click()
+
+      await expect(page).toHaveURL(`/${choice.locale}/${subpage}`)
+      await expect(page.locator('html')).toHaveAttribute('lang', choice.locale)
+      await exposeLanguageNavigation(page, isMobile)
+      await expect(
+        page.locator('a.language-switch[aria-current="language"]')
+      ).toHaveText(choice.label)
     }
-    await expect(
-      page.locator('a.language-switch[aria-current="language"]')
-    ).toHaveText(choice.label)
   }
 })

--- a/tests/e2e/mobile-navigation.spec.ts
+++ b/tests/e2e/mobile-navigation.spec.ts
@@ -17,19 +17,21 @@ async function seriousOrCriticalToggleViolations(page: Page) {
 }
 
 test.describe('mobile navigation', () => {
-  test.skip(
-    ({ isMobile }) => !isMobile,
-    'Mobile navigation is viewport-specific'
-  )
-
   test.beforeEach(async ({ page }) => {
     await page.goto(spanishHome.path)
   })
 
   test('exposes state and supports pointer and keyboard activation', async ({
     page,
+    isMobile,
   }) => {
     const toggle = page.locator('#mobile-navigation-toggle')
+
+    if (!isMobile) {
+      await expect(toggle).toBeHidden()
+      await expect(page.getByRole('navigation')).toBeVisible()
+      return
+    }
 
     await expect(toggle).toHaveAccessibleName('menu')
     await expect(toggle).toHaveAttribute('aria-expanded', 'false')
@@ -60,10 +62,13 @@ test.describe('mobile navigation', () => {
     await expect(toggle).toHaveAttribute('aria-expanded', 'false')
   })
 
-  test('navigates through a localized menu link', async ({ page }) => {
+  test('navigates through a localized menu link', async ({
+    page,
+    isMobile,
+  }) => {
     const toggle = page.getByRole('button', { name: 'menu' })
 
-    await toggle.click()
+    if (isMobile) await toggle.click()
     await page.getByRole('link', { name: 'Contacto' }).click()
 
     await expect(page).toHaveURL(/\/es\/contact\/?$/)

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test, type Page } from './fixtures/health'
+
+async function exposeNavigation(page: Page) {
+  const navigation = page.getByRole('navigation')
+  if (!(await navigation.isVisible())) {
+    await page.getByRole('button', { name: 'menu' }).click()
+  }
+  await expect(navigation).toBeVisible()
+  return navigation
+}
+
+test('supports the primary navigation journeys', async ({ page, isMobile }) => {
+  await page.goto('/en')
+
+  if (isMobile) {
+    await expect(page.getByRole('button', { name: 'menu' })).toBeVisible()
+    await expect(page.getByRole('navigation')).toBeHidden()
+  } else {
+    await expect(page.locator('#mobile-navigation-toggle')).toBeHidden()
+    await expect(page.getByRole('navigation')).toBeVisible()
+  }
+
+  await page.getByRole('link', { name: 'Cases Worked' }).click()
+  await expect(page).toHaveURL(/\/en\/cases\/?$/)
+
+  await page.getByRole('link', { name: /El Danés logo/ }).click()
+  await expect(page).toHaveURL(/\/en\/?$/)
+
+  const navigation = await exposeNavigation(page)
+  await navigation.getByRole('link', { name: 'Contact' }).click()
+  await expect(page).toHaveURL(/\/en\/contact\/?$/)
+})

--- a/tests/e2e/source-flip.spec.ts
+++ b/tests/e2e/source-flip.spec.ts
@@ -1,25 +1,62 @@
-import { expect, test, type Page } from '@playwright/test'
+import { expect, test, type Page } from './fixtures/health'
 
 const sourceFlip = (page: Page) =>
   page.getByRole('switch', { name: 'Show code' })
 
-test('only exposes the source-code flip when source is available', async ({
-  page,
-}) => {
+async function exposeSourceFlip(page: Page, isMobile: boolean) {
+  if (isMobile) {
+    await page.getByRole('button', { name: 'menu' }).click()
+  }
+  await expect(sourceFlip(page)).toHaveCount(1)
+  await expect(sourceFlip(page)).toBeVisible()
+}
+
+for (const path of ['/en', '/en/cases', '/en/contact'] as const) {
+  test(`exposes populated reversible source on ${path}`, async ({
+    page,
+    isMobile,
+  }) => {
+    await page.goto(path)
+    await exposeSourceFlip(page, isMobile)
+
+    await sourceFlip(page).click()
+    await expect(sourceFlip(page)).toHaveAttribute('aria-checked', 'true')
+    await expect(page.locator('main code')).not.toBeEmpty()
+
+    await sourceFlip(page).click()
+    await expect(sourceFlip(page)).not.toHaveAttribute('aria-checked', 'true')
+    await expect(page.locator('main code')).toHaveCount(0)
+  })
+}
+
+test('does not expose source on the wallet', async ({ page }, testInfo) => {
+  if (testInfo.project.name === 'mobile-chromium') {
+    await page.route('https://pay.google.com/**', (route) => route.abort())
+    const handoff = page.waitForEvent('request', {
+      predicate: (request) =>
+        request.url().startsWith('https://pay.google.com/gp/v/save/'),
+    })
+    await page.goto('/en/contact/christian')
+    expect(new URL((await handoff).url()).protocol).toBe('https:')
+    return
+  }
+
+  if (testInfo.project.name === 'webkit') {
+    await page.route('**/el-danes.pkpass', (route) => route.abort())
+    const handoff = page.waitForEvent('request', {
+      predicate: (request) => request.url().endsWith('/el-danes.pkpass'),
+    })
+    await page.goto('/en/contact/christian')
+    expect(new URL((await handoff).url()).pathname).toBe('/el-danes.pkpass')
+    return
+  }
+
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'userAgent', {
+      configurable: true,
+      get: () => 'Mozilla/5.0 (X11; Linux x86_64)',
+    })
+  })
   await page.goto('/en/contact/christian')
   await expect(sourceFlip(page)).toHaveCount(0)
-
-  await page.goto('/en')
-  if ((await sourceFlip(page).count()) === 0) {
-    await page.getByRole('button', { name: 'Menu' }).click()
-  }
-  await expect(sourceFlip(page)).toBeVisible()
-
-  await sourceFlip(page).click()
-  await expect(sourceFlip(page)).toHaveAttribute('aria-checked', 'true')
-  await expect(page.locator('main code')).not.toBeEmpty()
-
-  await sourceFlip(page).click()
-  await expect(sourceFlip(page)).not.toHaveAttribute('aria-checked', 'true')
-  await expect(page.locator('main code')).toHaveCount(0)
 })

--- a/tests/e2e/source-flip.spec.ts
+++ b/tests/e2e/source-flip.spec.ts
@@ -36,7 +36,7 @@ test('does not expose source on the wallet', async ({ page }, testInfo) => {
       predicate: (request) =>
         request.url().startsWith('https://pay.google.com/gp/v/save/'),
     })
-    await page.goto('/en/contact/christian')
+    await page.goto('/en/contact/christian', { waitUntil: 'commit' })
     expect(new URL((await handoff).url()).protocol).toBe('https:')
     return
   }
@@ -46,7 +46,7 @@ test('does not expose source on the wallet', async ({ page }, testInfo) => {
     const handoff = page.waitForEvent('request', {
       predicate: (request) => request.url().endsWith('/el-danes.pkpass'),
     })
-    await page.goto('/en/contact/christian')
+    await page.goto('/en/contact/christian', { waitUntil: 'commit' })
     expect(new URL((await handoff).url()).pathname).toBe('/el-danes.pkpass')
     return
   }

--- a/tests/e2e/theme.spec.ts
+++ b/tests/e2e/theme.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test, type Page } from './fixtures/health'
+
+const themeControl = (page: Page, theme: 'dark' | 'light') =>
+  page.getByRole('radio', { name: `Use ${theme} theme` })
+
+async function exposeThemeControls(page: Page, isMobile: boolean) {
+  if (isMobile) {
+    await page.getByRole('button', { name: 'menu' }).click()
+  }
+  await expect(themeControl(page, 'dark')).toBeVisible()
+}
+
+async function expectEffectiveTheme(page: Page, theme: 'dark' | 'light') {
+  await expect(page.locator('html')).toHaveCSS('--color-mode', theme)
+  await expect(themeControl(page, theme)).toHaveAttribute(
+    'aria-checked',
+    'true'
+  )
+}
+
+test('uses the initial system theme in a clean context', async ({
+  page,
+  isMobile,
+}) => {
+  await page.emulateMedia({ colorScheme: 'dark' })
+  await page.goto('/en')
+  await exposeThemeControls(page, isMobile)
+  await expectEffectiveTheme(page, 'dark')
+})
+
+test('persists the selected and effective theme across navigation and reload', async ({
+  page,
+  isMobile,
+}) => {
+  await page.goto('/en')
+  await exposeThemeControls(page, isMobile)
+
+  await themeControl(page, 'light').click()
+  await expectEffectiveTheme(page, 'light')
+  await expect(themeControl(page, 'dark')).not.toHaveAttribute(
+    'aria-checked',
+    'true'
+  )
+
+  await page.goto('/en/contact')
+  await exposeThemeControls(page, isMobile)
+  await expectEffectiveTheme(page, 'light')
+
+  await themeControl(page, 'dark').click()
+  await expectEffectiveTheme(page, 'dark')
+  await page.reload()
+  await exposeThemeControls(page, isMobile)
+  await expectEffectiveTheme(page, 'dark')
+})


### PR DESCRIPTION
## Summary
- cover primary navigation, locale preservation, mobile menu accessibility, theme persistence, and reversible source views
- validate case, contact, social, and wallet destinations without requesting third-party pages
- expose native mail links and enforce noopener for Google Wallet, with stable Android/iPhone handoff capture

## Verification
- `npm run check`
- `npm run check:e2e`
- focused desktop/mobile Playwright journeys (26 passed)
- focused Firefox/WebKit wallet and source journeys (17 passed after WebKit rerun)
- `npm run verify` (35 passed, 3 upstream wallet-title tests skipped; 18 resolver tests passed)

Closes #112